### PR TITLE
module_init: Replace module_init with late_initcall

### DIFF
--- a/p2pmem_pci.c
+++ b/p2pmem_pci.c
@@ -508,5 +508,5 @@ static void __exit p2pmem_pci_cleanup(void)
 	pr_info(KBUILD_MODNAME ": module unloaded\n");
 }
 
-module_init(p2pmem_pci_init);
+late_initcall(p2pmem_pci_init);
 module_exit(p2pmem_pci_cleanup);


### PR DESCRIPTION
When we install p2pmem-pci.ko into a kernel there is a chance it will
load before the device driver(s) for the PCIe devices that are
publishing p2pdma memory (nvme for example). Therefore we want this
module to load as late as possible via a late_initcall().

Fixes #2.