### PR TITLE
Remove ugly hacks and update support for the pci_mmap_p2pmem method

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -1,6 +1,7 @@
 li
 ol
 
+Eideticom
 CMBs
 Collaterals
 KDIR
@@ -9,6 +10,7 @@ NVM
 NVMF
 PCIe
 PMEM
+IOMEM
 
 api
 config

--- a/README.md
+++ b/README.md
@@ -1,19 +1,9 @@
 # P2PMEM PCIe Linux Driver
-
-## Disclaimer
-
-This driver exposes p2pmem to userspace without taking appropriate
-safety measures to ensure it is used correctly. If you do certain
-things with the pointers obtained by mmapping the /dev/p2pmemX exposed
-by this driver bad things will probably happen. Consider yourself
-warned.
-
 ## Introduction
 
 This is a standlone PCIe driver that ties into the [p2pmem][1]
-framework. It can be used for any PCIe end-point devices that have
-registered one or more PCIe BAR(s) with the p2pdma framework (e.g. [NVM
-Express CMBs][2]).
+framework. It can be used with the Eideticom IOMEM device (device ID 0x1000) to
+allow mmapping from the userspace.
 
 ## Build and Install
 
@@ -31,12 +21,11 @@ make install
 ```
 
 Note that for this to work you either need to have module signing set
-up or turned off on your machine. Also this code will only work for >=
-4.20.x kernels. Please look for the largest tag that is less than or
-equal to your kernel version and use that tag.
+up or turned off on your machine. Also this code will only work for kernels
+with the pci_mmap_p2pmem function.
 
 Often you don't want to compile against the kernel installed on your
-host so you can use the instructions [here][3] that describe how to
+host so you can use the instructions [here][2] that describe how to
 prepare a kernel tree for out-of-tree module compilation. The
 following process seems to work well (in the top level kernel source
 folder):
@@ -53,7 +42,7 @@ warning when you build the module.
 WARNING: Symbol version dump ./Module.symvers
 is missing; modules will have no dependencies and modversions.
 ```
-This behaviour is [expected][3].
+This behaviour is [expected][2].
 
 ## Usage
 
@@ -64,11 +53,10 @@ associated with /dev/p2pmemX. You can then pass these pointers into
 library functions like write() and read() *as long as you use
 O_DIRECT*.
 
-An example of how to use /dev/p2pmemX is via [p2pmem-test][4] which
+An example of how to use /dev/p2pmemX is via [p2pmem-test][3] which
 also has more information on setting up p2pdma enabled kernels and a
 p2pdma capable system.
 
 [1]: https://www.kernel.org/doc/html/latest/driver-api/pci/p2pdma.html
-[2]: https://www.flashmemorysummit.com/English/Collaterals/Proceedings/2018/20180809_NVMF-301-1_Maier.pdf
-[3]: https://www.kernel.org/doc/Documentation/kbuild/modules.txt
-[4]: https://github.com/sbates130272/p2pmem-test
+[2]: https://www.kernel.org/doc/Documentation/kbuild/modules.txt
+[3]: https://github.com/sbates130272/p2pmem-test

--- a/p2pmem_pci.c
+++ b/p2pmem_pci.c
@@ -53,100 +53,13 @@ static struct p2pmem_dev *to_p2pmem(struct device *dev)
 	return container_of(dev, struct p2pmem_dev, dev);
 }
 
-struct p2pmem_vma {
-	struct p2pmem_dev *p2pmem_dev;
-	atomic_t mmap_count;
-	size_t nr_pages;
-
-	/* Protects the used_pages array */
-	struct mutex mutex;
-	struct page *used_pages[];
-};
-
-static void p2pmem_vma_open(struct vm_area_struct *vma)
-{
-	struct p2pmem_vma *pv = vma->vm_private_data;
-
-	atomic_inc(&pv->mmap_count);
-}
-
-static void p2pmem_vma_free_pages(struct vm_area_struct *vma)
-{
-	int i;
-	struct p2pmem_vma *pv = vma->vm_private_data;
-
-	mutex_lock(&pv->mutex);
-
-	for (i = 0; i < pv->nr_pages; i++) {
-		if (pv->used_pages[i]) {
-			pci_free_p2pmem(pv->p2pmem_dev->pdev,
-					page_to_virt(pv->used_pages[i]),
-					PAGE_SIZE);
-			pv->used_pages[i] = NULL;
-		}
-	}
-
-	mutex_unlock(&pv->mutex);
-}
-
-static void p2pmem_vma_close(struct vm_area_struct *vma)
-{
-	struct p2pmem_vma *pv = vma->vm_private_data;
-
-	if (!atomic_dec_and_test(&pv->mmap_count))
-		return;
-
-	p2pmem_vma_free_pages(vma);
-
-	dev_dbg(&pv->p2pmem_dev->dev, "vma close");
-	kfree(pv);
-}
-
-static vm_fault_t p2pmem_vma_fault(struct vm_fault *vmf)
-{
-	struct p2pmem_vma *pv = vmf->vma->vm_private_data;
-	unsigned int pg_idx;
-	struct page *pg;
-	pfn_t pfn;
-	vm_fault_t rc;
-
-	pg_idx = (vmf->address - vmf->vma->vm_start) / PAGE_SIZE;
-
-	mutex_lock(&pv->mutex);
-
-	if (pv->used_pages[pg_idx])
-		pg = pv->used_pages[pg_idx];
-	else
-		pg = virt_to_page(pci_alloc_p2pmem(pv->p2pmem_dev->pdev,
-						   PAGE_SIZE));
-
-	if (!pg) {
-		mutex_unlock(&pv->mutex);
-		return VM_FAULT_OOM;
-	}
-
-	pv->used_pages[pg_idx] = pg;
-
-	pfn = phys_to_pfn_t(page_to_phys(pg), PFN_DEV | PFN_MAP);
-	rc = vmf_insert_mixed(vmf->vma, vmf->address, pfn);
-
-	mutex_unlock(&pv->mutex);
-
-	return rc;
-}
-
-const struct vm_operations_struct p2pmem_vmops = {
-	.open = p2pmem_vma_open,
-	.close = p2pmem_vma_close,
-	.fault = p2pmem_vma_fault,
-};
-
 static int p2pmem_open(struct inode *inode, struct file *filp)
 {
 	struct p2pmem_dev *p;
 
 	p = container_of(inode->i_cdev, struct p2pmem_dev, cdev);
 	filp->private_data = p;
+	pci_p2pdma_file_open(p->pdev, filp);
 
 	return 0;
 }
@@ -154,31 +67,8 @@ static int p2pmem_open(struct inode *inode, struct file *filp)
 static int p2pmem_mmap(struct file *filp, struct vm_area_struct *vma)
 {
 	struct p2pmem_dev *p = filp->private_data;
-	struct p2pmem_vma *pv;
-	size_t nr_pages = (vma->vm_end - vma->vm_start) / PAGE_SIZE;
 
-	if ((vma->vm_flags & VM_MAYSHARE) != VM_MAYSHARE) {
-		dev_warn(&p->dev, "mmap failed: can't create private mapping\n");
-		return -EINVAL;
-	}
-
-	dev_dbg(&p->dev, "Allocating mmap with %zd pages.\n", nr_pages);
-
-	pv = kzalloc(sizeof(*pv) + sizeof(pv->used_pages[0]) * nr_pages,
-		     GFP_KERNEL);
-	if (!pv)
-		return -ENOMEM;
-
-	mutex_init(&pv->mutex);
-	pv->nr_pages = nr_pages;
-	pv->p2pmem_dev = p;
-	atomic_set(&pv->mmap_count, 1);
-
-	vma->vm_private_data = pv;
-	vma->vm_ops = &p2pmem_vmops;
-	vma->vm_flags |= VM_MIXEDMAP;
-
-	return 0;
+	return pci_mmap_p2pmem(p->pdev, vma);
 }
 
 static const struct file_operations p2pmem_fops = {
@@ -360,7 +250,7 @@ static int p2pmem_pci_probe(struct pci_dev *pdev,
 		goto out;
 	}
 
-	err = pci_p2pdma_add_resource(pdev, id->driver_data, 0, 0);
+	err = pci_p2pdma_add_resource(pdev, 0, 0, 0);
 	if (err) {
 		dev_err(&pdev->dev, "unable to add p2p resource");
 		goto out_disable_device;


### PR DESCRIPTION
The older versions of this driver are deprecated and no longer used. However, we need something to be able to mmap for the Eideticom IOMEM device that simply makes use of the new pci_mmap_p2pmem function.